### PR TITLE
Reduced gpu utilization

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,9 +138,10 @@ def main():
         from renderer_cuda import CUDARenderer
         g_renderer_list += [CUDARenderer(g_camera.w, g_camera.h)]
     except ImportError:
-        pass
-    
-    g_renderer_idx = BACKEND_OGL
+        g_renderer_idx = BACKEND_OGL
+    else:
+        g_renderer_idx = BACKEND_CUDA
+
     g_renderer = g_renderer_list[g_renderer_idx]
 
     # gaussian data

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ g_renderer_list = [
     None, # ogl
 ]
 g_renderer_idx = BACKEND_OGL
-g_renderer = g_renderer_list[g_renderer_idx]
+g_renderer: GaussianRenderBase = g_renderer_list[g_renderer_idx]
 g_scale_modifier = 1.
 g_auto_sort = False
 g_show_control_win = True
@@ -186,6 +186,11 @@ def main():
                     update_activated_renderer_state(gaussians)
 
                 imgui.text(f"fps = {imgui.get_io().framerate:.1f}")
+
+                changed, g_renderer.reduce_updates = imgui.checkbox(
+                        "reduce updates", g_renderer.reduce_updates,
+                    )
+
                 imgui.text(f"# of Gaus = {len(gaussians)}")
                 if imgui.button(label='open ply'):
                     file_path = filedialog.askopenfilename(title="open ply",

--- a/renderer_cuda.py
+++ b/renderer_cuda.py
@@ -132,6 +132,12 @@ class CUDARenderer(GaussianRenderBase):
 
         self.need_rerender = True
 
+        try:
+            from OpenGL.raw.WGL.EXT.swap_control import wglSwapIntervalEXT
+            wglSwapIntervalEXT(1)
+        except:
+            print("VSync not supported")
+
     def update_gaussian_data(self, gaus: util_gau.GaussianData):
         self.need_rerender = True
         self.gaussians = gaus_cuda_from_cpu(gaus)

--- a/renderer_ogl.py
+++ b/renderer_ogl.py
@@ -128,6 +128,12 @@ class OpenGLRenderer(GaussianRenderBase):
         gl.glEnable(gl.GL_BLEND)
         gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
 
+        try:
+            from OpenGL.raw.WGL.EXT.swap_control import wglSwapIntervalEXT
+            wglSwapIntervalEXT(1)
+        except:
+            print("VSync not supported")
+
     def update_gaussian_data(self, gaus: util_gau.GaussianData):
         self.gaussians = gaus
         # load gaussian geometry

--- a/renderer_ogl.py
+++ b/renderer_ogl.py
@@ -3,6 +3,12 @@ import util
 import util_gau
 import numpy as np
 
+try:
+    from OpenGL.raw.WGL.EXT.swap_control import wglSwapIntervalEXT
+except:
+    wglSwapIntervalEXT = None
+
+
 _sort_buffer_xyz = None
 _sort_buffer_gausid = None  # used to tell whether gaussian is reloaded
 
@@ -73,6 +79,19 @@ except ImportError:
 class GaussianRenderBase:
     def __init__(self):
         self.gaussians = None
+        self._reduce_updates = True
+
+    @property
+    def reduce_updates(self):
+        return self._reduce_updates
+
+    @reduce_updates.setter
+    def reduce_updates(self, val):
+        self._reduce_updates = val
+        self.update_vsync()
+
+    def update_vsync(self):
+        print("VSync is not supported")
 
     def update_gaussian_data(self, gaus: util_gau.GaussianData):
         raise NotImplementedError()
@@ -128,11 +147,13 @@ class OpenGLRenderer(GaussianRenderBase):
         gl.glEnable(gl.GL_BLEND)
         gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
 
-        try:
-            from OpenGL.raw.WGL.EXT.swap_control import wglSwapIntervalEXT
-            wglSwapIntervalEXT(1)
-        except:
-            print("VSync not supported")
+        self.update_vsync()
+
+    def update_vsync(self):
+        if wglSwapIntervalEXT is not None:
+            wglSwapIntervalEXT(1 if self.reduce_updates else 0)
+        else:
+            print("VSync is not supported")
 
     def update_gaussian_data(self, gaus: util_gau.GaussianData):
         self.gaussians = gaus


### PR DESCRIPTION
The original version was maxing out my RTX 4080 (100% as observed in Windows 11 Task Manager), displaying an excessive and unnecessary FPS count of ~700. To address this, I've added VSync to cap the FPS and reduce workload. Furthermore, I've bit modified the rendering logic to only execute the GaussianRasterization when there are actual changes to the scene, camera, or window size. This modifications were effectively reduced the GPU load to single-digit percentages.
![image](https://github.com/limacv/GaussianSplattingViewer/assets/160430502/8f9be3f3-96e1-4b48-95f9-c243a63abf79)
